### PR TITLE
Support OpenAI as a TTS provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 
 # Node.js
 node_modules/
+package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -32,6 +33,7 @@ coverage/
 .env
 .env.*
 
+output/*-investor-demo/
 **/screenshots/*
 **/audio/*
 **/video-work/*

--- a/prompts/tts-prompt.md
+++ b/prompts/tts-prompt.md
@@ -5,7 +5,8 @@ You are generating narration audio from approved script content.
 ## Goals
 
 - Read `output/<presentation-slug>/script.json`.
-- Use DashScope TTS with `DASHSCOPE_API_KEY`.
+- Use the existing `scripts/tts_from_script.py` script — do not rewrite it.
+- Support either DashScope TTS with `DASHSCOPE_API_KEY` or OpenAI TTS with `OPENAI_API_KEY`.
 - Use the existing `scripts/tts_from_script.py` script — do not rewrite it.
 - Generate one mp3 **and one srt** per slide into `output/<presentation-slug>/audio/`.
 - Keep file names aligned with slide numbers.
@@ -30,21 +31,35 @@ Run the existing script with `uv run`:
 uv run scripts/tts_from_script.py --script output/<presentation-slug>/script.json
 ```
 
-This will:
+By default the script auto-detects the provider:
+
+- If `DASHSCOPE_API_KEY` is set, it uses DashScope first.
+- Otherwise, if `OPENAI_API_KEY` is set, it uses OpenAI.
+- You can override this with `--provider dashscope` or `--provider openai`.
+
+DashScope mode will:
 1. Call the DashScope CosyVoice TTS API with `word_timestamp_enabled: true`.
 2. Write `slide-XX.mp3` files to `output/<presentation-slug>/audio/`.
-3. Write `slide-XX.srt` files to the same `audio/` directory (character-level timestamps from the API).
+3. Write `slide-XX.srt` files to the same `audio/` directory.
+
+OpenAI mode will:
+1. Call the OpenAI `audio/speech` API.
+2. Write `slide-XX.mp3` files to `output/<presentation-slug>/audio/`.
+3. Skip SRT generation in the current workflow, even if `--no-srt` is not set.
 
 **Key CLI flags:**
 - `--script` — path to `script.json` (required unless default matches).
+- `--provider {auto,dashscope,openai}` — choose or auto-detect the TTS backend.
 - `--overwrite` — re-synthesize and overwrite existing mp3/srt files.
 - `--no-srt` — skip SRT generation (use only when subtitles are not needed).
-- `--voice` / `--model` — override the default voice (`longanyang`) and model (`cosyvoice-v3-flash`).
+- `--voice` / `--model` — override provider-specific defaults.
+- `--instructions` — optional OpenAI-only speaking instructions such as pacing or tone.
 
 ## Implementation notes (for reference only)
 
 - The script uses `dashscope.audio.tts_v2.SpeechSynthesizer` in streaming callback mode.
 - `word_timestamp_enabled` is passed in `additional_params` so the server returns per-character `begin_time`/`end_time` (milliseconds) in `result-generated` events.
 - A fresh synthesizer is created per narration to satisfy the SDK connection lifecycle.
-- Fails clearly when `DASHSCOPE_API_KEY` is missing or the TTS API returns no audio.
+- OpenAI mode uses the official `audio/speech` endpoint and currently returns MP3 only in this workflow.
+- Fails clearly when no provider credentials are present or the TTS API returns no audio.
 - Uses the Beijing DashScope WebSocket endpoint (`wss://dashscope.aliyuncs.com/api-ws/v1/inference`) by default.

--- a/scripts/tts_from_script.py
+++ b/scripts/tts_from_script.py
@@ -2,6 +2,7 @@
 # /// script
 # dependencies = [
 #   "dashscope>=1.24.6",
+#   "openai>=1.109.0",
 # ]
 # ///
 
@@ -11,12 +12,17 @@ import argparse
 import json
 import os
 import threading
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Callable
 
 
-DEFAULT_MODEL = "cosyvoice-v3-flash"
-DEFAULT_VOICE = "longanyang"
+DEFAULT_PROVIDER = "auto"
+DEFAULT_DASHSCOPE_MODEL = "cosyvoice-v3-flash"
+DEFAULT_DASHSCOPE_VOICE = "longanyang"
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
+DEFAULT_OPENAI_VOICE = "coral"
 DEFAULT_SCRIPT = Path("output/tools-keyboard-first-workflow/script.json")
 DEFAULT_BASE_WEBSOCKET_API_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/inference"
 
@@ -246,6 +252,57 @@ def make_dashscope_synthesizer(
     return synthesize
 
 
+def make_openai_synthesizer(
+    model: str,
+    voice: str,
+    api_key: str,
+    instructions: str | None = None,
+    response_format: str = "mp3",
+) -> Callable[[str], tuple[bytes, list[dict[str, Any]]]]:
+    """Return a synthesize(text) callable backed by OpenAI's audio/speech API."""
+
+    endpoint = "https://api.openai.com/v1/audio/speech"
+
+    def synthesize(text: str) -> tuple[bytes, list[dict[str, Any]]]:
+        payload: dict[str, Any] = {
+            "model": model,
+            "voice": voice,
+            "input": text,
+            "response_format": response_format,
+        }
+        if instructions:
+            payload["instructions"] = instructions
+
+        request = urllib.request.Request(
+            endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(request) as response:
+                audio = response.read()
+        except urllib.error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"OpenAI TTS request failed with status {exc.code}: {details}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"OpenAI TTS request failed: {exc.reason}") from exc
+
+        if not audio:
+            raise RuntimeError(
+                f"OpenAI TTS returned no audio for model={model!r} voice={voice!r}"
+            )
+        return audio, []
+
+    return synthesize
+
+
 def synthesize_script_entries(
     entries: list[dict[str, Any]],
     output_dir: Path,
@@ -302,14 +359,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Directory for generated MP3 files. Defaults to an audio/ folder next to script.json.",
     )
     parser.add_argument(
+        "--provider",
+        choices=["auto", "dashscope", "openai"],
+        default=DEFAULT_PROVIDER,
+        help="TTS provider to use. Defaults to auto-detect from environment variables.",
+    )
+    parser.add_argument(
         "--model",
-        default=DEFAULT_MODEL,
-        help="DashScope TTS model.",
+        help="Override the provider-specific TTS model.",
     )
     parser.add_argument(
         "--voice",
-        default=DEFAULT_VOICE,
-        help="DashScope voice name or custom voice id.",
+        help="Override the provider-specific voice name.",
     )
     parser.add_argument(
         "--base-websocket-api-url",
@@ -326,27 +387,77 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Skip SRT subtitle file generation (enabled by default).",
     )
+    parser.add_argument(
+        "--instructions",
+        help="Optional OpenAI TTS speaking instructions, such as tone or pacing.",
+    )
     return parser.parse_args(argv)
+
+
+def resolve_provider_and_api_key(provider: str) -> tuple[str, str]:
+    dashscope_api_key = os.getenv("DASHSCOPE_API_KEY")
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+
+    if provider == "dashscope":
+        if not dashscope_api_key:
+            raise SystemExit("DASHSCOPE_API_KEY is required when --provider=dashscope")
+        return provider, dashscope_api_key
+
+    if provider == "openai":
+        if not openai_api_key:
+            raise SystemExit("OPENAI_API_KEY is required when --provider=openai")
+        return provider, openai_api_key
+
+    if dashscope_api_key:
+        return "dashscope", dashscope_api_key
+    if openai_api_key:
+        return "openai", openai_api_key
+
+    raise SystemExit(
+        "No TTS credentials found. Set DASHSCOPE_API_KEY or OPENAI_API_KEY, "
+        "or pass --provider explicitly."
+    )
+
+
+def resolve_model_and_voice(
+    provider: str, model: str | None, voice: str | None
+) -> tuple[str, str]:
+    if provider == "dashscope":
+        return model or DEFAULT_DASHSCOPE_MODEL, voice or DEFAULT_DASHSCOPE_VOICE
+    return model or DEFAULT_OPENAI_MODEL, voice or DEFAULT_OPENAI_VOICE
 
 
 def main() -> int:
     args = parse_args()
-    api_key = os.getenv("DASHSCOPE_API_KEY")
-    if not api_key:
-        raise SystemExit("DASHSCOPE_API_KEY is required")
-
+    provider, api_key = resolve_provider_and_api_key(args.provider)
+    model, voice = resolve_model_and_voice(provider, args.model, args.voice)
     write_srt = not args.no_srt
 
     script_path = args.script.resolve()
     entries = load_script_entries(script_path)
     output_dir = resolve_output_dir(script_path, args.output_dir)
-    synthesize = make_dashscope_synthesizer(
-        model=args.model,
-        voice=args.voice,
-        api_key=api_key,
-        base_websocket_api_url=args.base_websocket_api_url,
-        enable_timestamps=write_srt,
-    )
+
+    if provider == "dashscope":
+        synthesize = make_dashscope_synthesizer(
+            model=model,
+            voice=voice,
+            api_key=api_key,
+            base_websocket_api_url=args.base_websocket_api_url,
+            enable_timestamps=write_srt,
+        )
+    else:
+        if write_srt:
+            print(
+                "warning: OpenAI TTS currently writes MP3 only in this workflow; "
+                "SRT generation is skipped. Use --no-srt to silence this warning."
+            )
+        synthesize = make_openai_synthesizer(
+            model=model,
+            voice=voice,
+            api_key=api_key,
+            instructions=args.instructions,
+        )
+
     written_files = synthesize_script_entries(
         entries=entries,
         output_dir=output_dir,

--- a/tests/test_tts_from_script.py
+++ b/tests/test_tts_from_script.py
@@ -1,8 +1,10 @@
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 def load_module():
@@ -73,9 +75,50 @@ class ParseArgsTests(unittest.TestCase):
             module.DEFAULT_SCRIPT,
             Path("output/tools-keyboard-first-workflow/script.json"),
         )
-        self.assertEqual(module.DEFAULT_MODEL, "cosyvoice-v3-flash")
-        self.assertEqual(module.DEFAULT_VOICE, "longanyang")
+        self.assertEqual(module.DEFAULT_DASHSCOPE_MODEL, "cosyvoice-v3-flash")
+        self.assertEqual(module.DEFAULT_DASHSCOPE_VOICE, "longanyang")
+        self.assertEqual(module.DEFAULT_OPENAI_MODEL, "gpt-4o-mini-tts")
+        self.assertEqual(module.DEFAULT_OPENAI_VOICE, "coral")
         self.assertEqual(args.voice, "override-voice")
+        self.assertEqual(args.provider, "auto")
+
+
+class ProviderResolutionTests(unittest.TestCase):
+    def test_auto_prefers_dashscope_when_available(self) -> None:
+        module = load_module()
+
+        with mock.patch.dict(
+            os.environ,
+            {"DASHSCOPE_API_KEY": "dash-key", "OPENAI_API_KEY": "open-key"},
+            clear=False,
+        ):
+            provider, api_key = module.resolve_provider_and_api_key("auto")
+
+        self.assertEqual((provider, api_key), ("dashscope", "dash-key"))
+
+    def test_auto_uses_openai_when_dashscope_missing(self) -> None:
+        module = load_module()
+
+        with mock.patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "open-key"},
+            clear=True,
+        ):
+            provider, api_key = module.resolve_provider_and_api_key("auto")
+
+        self.assertEqual((provider, api_key), ("openai", "open-key"))
+
+    def test_provider_specific_defaults_follow_provider(self) -> None:
+        module = load_module()
+
+        self.assertEqual(
+            module.resolve_model_and_voice("dashscope", None, None),
+            ("cosyvoice-v3-flash", "longanyang"),
+        )
+        self.assertEqual(
+            module.resolve_model_and_voice("openai", None, None),
+            ("gpt-4o-mini-tts", "coral"),
+        )
 
 
 class SynthesizeEntriesTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

  This PR adds OpenAI as a supported TTS backend for `md2video` while keeping the existing DashScope
  flow intact.

  ### What changed

  - Add `--provider {auto,dashscope,openai}` to `scripts/tts_from_script.py`
  - Support automatic provider selection from environment variables
    - prefer `DASHSCOPE_API_KEY`
    - fall back to `OPENAI_API_KEY`
  - Add OpenAI TTS support via `POST /v1/audio/speech`
  - Add `--instructions` for OpenAI speaking style control
  - Keep DashScope as the default path when available
  - Preserve existing DashScope SRT generation behavior
  - Document the dual-provider workflow in `prompts/tts-prompt.md`
  - Add tests for provider resolution and provider-specific defaults
  - Ignore generated `output/*-investor-demo/` directories and `package-lock.json`

  ## Behavior notes

  - DashScope mode continues to generate both `mp3` and `srt`
  - OpenAI mode currently generates `mp3` only
  - If `--provider` is not specified:
    - use DashScope when `DASHSCOPE_API_KEY` is present
    - otherwise use OpenAI when `OPENAI_API_KEY` is present

  ## Testing

  ```bash
  python3 -m unittest /home/lexmount/project/backend/md2video/tests/test_tts_from_script.py

  ## Why

  This makes the TTS step usable for environments where DashScope is unavailable or where teams
  already standardize on OpenAI credentials and APIs, without breaking the existing DashScope-based
  workflow.